### PR TITLE
Use Chandra::Time

### DIFF
--- a/Convert.pm
+++ b/Convert.pm
@@ -105,11 +105,16 @@ sub date2time {
     # second argument can be used to request return time as unix seconds
     my $want_unix_secs = shift;
     # if this is delta date from the DOT, just cheat and use a full
-    # date relative to year 2000 (unix time would be moot here)
-    if ($date =~ /^\d{3}:\d{2}\:\d{2}:\d{2}\.\d{3}$/){
-        my $year = '2000';
-        return (Chandra::Time->new("${year}:${date}")->secs()
-                - Chandra::Time->new("${year}:000:00:00:00.000")->secs());
+    # date relative to year 2000 day 1 (unix time would be moot here)
+    my ($date_day, $date_rest);
+    if ($date =~ /^(\d{3}):(\d{2}\:\d{2}:\d{2}\.\d{3})$/){
+        $date_day = $1;
+        $date_rest = $2;
+        # Planning to subtract time from 2000:001 so add the day to doy 1
+        my $mock_doy = 1 + $date_day;
+        # Calculate the delta time in seconds from 2000:001
+        return (Chandra::Time->new("2000:${mock_doy}:${date_rest}")->secs()
+                - Chandra::Time->new("2000:001:00:00:00.000")->secs());
     }
     if (defined $want_unix_secs){
         return Chandra::Time->new($date)->unix();

--- a/Convert.pm
+++ b/Convert.pm
@@ -87,6 +87,11 @@ sub time2date {
 ###################################################################################
 # Date format:  1999:260:03:30:01.542
     my $time = shift;
+    # second argument can be used to define input time as unix time
+    my $is_unix_time = shift;
+    if (defined $is_unix_time){
+        return Chandra::Time->new($time, { format=> 'unix' })->date();
+    }
     return Chandra::Time->new($time)->date();
 }
 
@@ -97,6 +102,11 @@ sub date2time {
 # 956245305.5 = eng_decom (unix) time at VCDU = 4324480 around 2000:111:15:41:46 (2000-04-20T15:42:50)
 # CXC Time from CCDM file is 72632569.96
     my $date = shift;
+    # second argument can be used to request return time as unix seconds
+    my $want_unix_secs = shift;
+    if (defined $want_unix_secs){
+        return Chandra::Time->new($date)->unix();
+    }
     return Chandra::Time->new($date)->secs();
 }
 

--- a/Convert.pm
+++ b/Convert.pm
@@ -92,7 +92,9 @@ sub time2date {
     if (defined $is_unix_time){
         return Chandra::Time->new($time, { format=> 'unix' })->date();
     }
-    return Chandra::Time->new($time)->date();
+    else{
+        return Chandra::Time->new($time)->date();
+    }
 }
 
 ##***************************************************************************
@@ -119,7 +121,9 @@ sub date2time {
     if (defined $want_unix_secs){
         return Chandra::Time->new($date)->unix();
     }
-    return Chandra::Time->new($date)->secs();
+    else{
+        return Chandra::Time->new($date)->secs();
+    }
 }
 
 ##**********************************************************************

--- a/Convert.pm
+++ b/Convert.pm
@@ -106,18 +106,10 @@ sub date2time {
     my $date = shift;
     # second argument can be used to request return time as unix seconds
     my $want_unix_secs = shift;
-    # if this is delta date from the DOT, just cheat and use a full
-    # date relative to year 2000 day 1 (unix time would be moot here)
-    my ($date_day, $date_rest);
-    if ($date =~ /^(\d{3}):(\d{2}\:\d{2}:\d{2}\.\d{3})$/){
-        $date_day = $1;
-        $date_rest = $2;
-        # Planning to subtract time from 2000:001 so add the day to doy 1
-        my $mock_doy = 1 + $date_day;
-        # Calculate the delta time in seconds from 2000:001
-        return (Chandra::Time->new("2000:${mock_doy}:${date_rest}")->secs()
-                - Chandra::Time->new("2000:001:00:00:00.000")->secs());
-    }
+    # if this is delta date from the DOT it will have no $yr
+    my ($sec, $min, $hr, $doy, $yr) = reverse split ":", $date;
+    return ($doy*86400 + $hr*3600 + $min*60 + $sec) if (not defined $yr);
+
     if (defined $want_unix_secs){
         return Chandra::Time->new($date)->unix();
     }

--- a/Convert.pm
+++ b/Convert.pm
@@ -104,6 +104,13 @@ sub date2time {
     my $date = shift;
     # second argument can be used to request return time as unix seconds
     my $want_unix_secs = shift;
+    # if this is delta date from the DOT, just cheat and use a full
+    # date relative to year 2000 (unix time would be moot here)
+    if ($date =~ /^\d{3}:\d{2}\:\d{2}:\d{2}\.\d{3}$/){
+        my $year = '2000';
+        return (Chandra::Time->new("${year}:${date}")->secs()
+                - Chandra::Time->new("${year}:000:00:00:00.000")->secs());
+    }
     if (defined $want_unix_secs){
         return Chandra::Time->new($date)->unix();
     }

--- a/Convert.pm
+++ b/Convert.pm
@@ -2,9 +2,7 @@ package Ska::Convert;
 
 use POSIX;
 use Text::ParseWords;
-use Time::JulianDay;
-use Time::DayOfYear;
-use Time::Local;
+use Chandra::Time;
 use Carp;
 
 use strict;
@@ -89,12 +87,7 @@ sub time2date {
 ###################################################################################
 # Date format:  1999:260:03:30:01.542
     my $time = shift;
-    my $t1998 = @_ ? 0.0 : 883612736.816; # 2nd argument implies Unix time not CXC time
-    my $floor_time = floor($time+$t1998);
-    my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = gmtime($floor_time);
-
-    return sprintf ("%04d:%03d:%02d:%02d:%06.3f",
-		    $year+1900, $yday+1, $hour, $min, $sec + ($time+$t1998-$floor_time));
+    return Chandra::Time->new($time)->date();
 }
 
 ##***************************************************************************
@@ -103,17 +96,8 @@ sub date2time {
 # Date format:  1999:260:03:30:01.542
 # 956245305.5 = eng_decom (unix) time at VCDU = 4324480 around 2000:111:15:41:46 (2000-04-20T15:42:50)
 # CXC Time from CCDM file is 72632569.96
-
     my $date = shift;
-    my $t1998 = @_ ? 0.0 : 956245305.5- 72632569.96 + 1.276; # 2nd argument implies Unix time not CXC time
-    my ($sec, $min, $hr, $doy, $yr) = reverse split ":", $date;
-
-    return ($doy*86400 + $hr*3600 + $min*60 + $sec) unless ($yr);
-
-    my ($mon, $day) = ydoy2md($yr, $doy);
-
-    $sec = 59 if ($sec > 59);
-    return timegm($sec,$min,$hr,$day,$mon-1,$yr) - $t1998;
+    return Chandra::Time->new($date)->secs();
 }
 
 ##**********************************************************************

--- a/Convert.pm
+++ b/Convert.pm
@@ -23,7 +23,7 @@ require Exporter;
 
 %EXPORT_TAGS = (all => \@EXPORT_OK);
 
-$VERSION = '0.02';
+$VERSION = '4.3';
 
 1;
 

--- a/Convert.pm
+++ b/Convert.pm
@@ -23,7 +23,7 @@ require Exporter;
 
 %EXPORT_TAGS = (all => \@EXPORT_OK);
 
-$VERSION = '0.01';
+$VERSION = '0.02';
 
 1;
 

--- a/test.pl
+++ b/test.pl
@@ -45,3 +45,7 @@ print "$test:  date2time relative mode\n";
 $ok = (abs(date2time('000:00:00:15.000') - 15) < 1e-15);
 print $ok ? "ok" : "not ok", " ", $test++, "\n";
 
+print "$test:  date2time more recent\n";
+$ok = (abs(date2time('2017:010:23:35:30.000') - 600478599.184) < 1e-15);
+print $ok ? "ok" : "not ok", " ", $test++, "\n";
+

--- a/test.pl
+++ b/test.pl
@@ -28,3 +28,16 @@ print $ok ? "ok" : "not ok", " ", $test++, "\n";
 print "$test:  time2date\n";
 $ok = (time2date(12345678.9) eq '1998:143:21:20:15.716');
 print $ok ? "ok" : "not ok", " ", $test++, "\n";
+
+print "$test:  time2date unix mode\n";
+$ok = (time2date(895958415, 'unix') eq '1998:143:21:20:15.000');
+print $ok ? "ok" : "not ok", " ", $test++, "\n";
+
+print "$test:  date2time\n";
+$ok = (abs(date2time('1998:143:21:20:15.716') - 12345678.900000000) < 1e-15);
+print $ok ? "ok" : "not ok", " ", $test++, "\n";
+
+print "$test:  date2time unix mode\n";
+$ok = (abs(date2time('1998:143:21:20:15.716', 'unix') - 895958415.716) < 1e-15);
+print $ok ? "ok" : "not ok", " ", $test++, "\n";
+

--- a/test.pl
+++ b/test.pl
@@ -25,6 +25,7 @@ print "$test:  dec2hms\n";
 $ok = ($rah eq '8:13:49.440' && $dms eq '+54:19:15.60');
 print $ok ? "ok" : "not ok", " ", $test++, "\n";
 
+# Time regression values confirmed with Chandra.Time 3.20.2 on ska3
 print "$test:  time2date\n";
 $ok = (time2date(12345678.9) eq '1998:143:21:20:15.716');
 print $ok ? "ok" : "not ok", " ", $test++, "\n";
@@ -41,11 +42,16 @@ print "$test:  date2time unix mode\n";
 $ok = (abs(date2time('1998:143:21:20:15.716', 'unix') - 895958415.716) < 1e-15);
 print $ok ? "ok" : "not ok", " ", $test++, "\n";
 
-print "$test:  date2time relative mode\n";
-$ok = (abs(date2time('000:00:00:15.000') - 15) < 1e-15);
-print $ok ? "ok" : "not ok", " ", $test++, "\n";
-
 print "$test:  date2time more recent\n";
 $ok = (abs(date2time('2017:010:23:35:30.000') - 600478599.184) < 1e-15);
 print $ok ? "ok" : "not ok", " ", $test++, "\n";
 
+# Following regression test values just confirmed manually
+# (Chandra.Time does not support these relative formats)
+print "$test:  date2time relative mode 15s\n";
+$ok = (abs(date2time('000:00:00:15.000') - 15) < 1e-15);
+print $ok ? "ok" : "not ok", " ", $test++, "\n";
+
+print "$test:  date2time relative mode almost 11 days\n";
+$ok = (abs(date2time('010:23:12:09.100') - 947529.1) < 1e-15);
+print $ok ? "ok" : "not ok", " ", $test++, "\n";

--- a/test.pl
+++ b/test.pl
@@ -41,3 +41,7 @@ print "$test:  date2time unix mode\n";
 $ok = (abs(date2time('1998:143:21:20:15.716', 'unix') - 895958415.716) < 1e-15);
 print $ok ? "ok" : "not ok", " ", $test++, "\n";
 
+print "$test:  date2time relative mode\n";
+$ok = (abs(date2time('000:00:00:15.000') - 15) < 1e-15);
+print $ok ? "ok" : "not ok", " ", $test++, "\n";
+


### PR DESCRIPTION
date2time appears to give incorrect results in the old code on perl 5.18.2.  As we have no real reason to maintain that code anyway, I think it makes sense to just move this code to use Chandra::Time (instead of changing the calls in starcheck to use Chandra::Time or debugging the old date2time code).
